### PR TITLE
ODAA-185: Fixed JSON data target option

### DIFF
--- a/src/DataTarget/JsonHttpDataTarget.php
+++ b/src/DataTarget/JsonHttpDataTarget.php
@@ -23,7 +23,7 @@ use Doctrine\Common\Collections\Collection;
 class JsonHttpDataTarget extends AbstractHttpDataTarget
 {
     /**
-     * @Option(name="As object", description="Send data as a JSON object (the first row in the result)", type="bool", default=false)
+     * @Option(name="As object", description="Send data as a JSON object (the first row in the result)", type="choice", choices={"No": false, "Yes":true}, required=true)
      */
     private $asObject;
 


### PR DESCRIPTION
We have a bug with `bool` options. This adds a workaround for the `JsonHttpDataTarget` class.